### PR TITLE
Fix #10 streamDecrypt ignoring custom S3 disk

### DIFF
--- a/src/FileVault.php
+++ b/src/FileVault.php
@@ -172,7 +172,7 @@ class FileVault
 
     protected function isS3File()
     {
-        return ($this->adapter instanceof AwsS3Adapter);
+        return ($this->adapter instanceof \League\Flysystem\AwsS3v3\AwsS3Adapter);
     }
 
     protected function setAdapter()

--- a/src/FileVault.php
+++ b/src/FileVault.php
@@ -172,7 +172,7 @@ class FileVault
 
     protected function isS3File()
     {
-        return ($this->adapter instanceof \League\Flysystem\AwsS3v3\AwsS3Adapter);
+        return $this->adapter instanceof \League\Flysystem\AwsS3v3\AwsS3Adapter;
     }
 
     protected function setAdapter()

--- a/src/FileVault.php
+++ b/src/FileVault.php
@@ -172,7 +172,7 @@ class FileVault
 
     protected function isS3File()
     {
-        return $this->adapter instanceof AwsS3Adapter;
+        return ($this->adapter instanceof AwsS3Adapter);
     }
 
     protected function setAdapter()

--- a/src/FileVault.php
+++ b/src/FileVault.php
@@ -31,7 +31,7 @@ class FileVault
     /**
      * The storage adapter.
      *
-     * @var string
+     * @var AdapterInterface
      */
     protected $adapter;
 
@@ -172,15 +172,11 @@ class FileVault
 
     protected function isS3File()
     {
-        return $this->disk instanceof AwsS3Adapter;
+        return $this->adapter instanceof AwsS3Adapter;
     }
 
     protected function setAdapter()
     {
-        if ($this->adapter) {
-            return;
-        }
-
         $this->adapter = Storage::disk($this->disk)->getAdapter();
     }
 

--- a/src/FileVault.php
+++ b/src/FileVault.php
@@ -172,7 +172,7 @@ class FileVault
 
     protected function isS3File()
     {
-        return $this->disk == 's3';
+        return $this->disk instanceof AwsS3Adapter;
     }
 
     protected function setAdapter()


### PR DESCRIPTION
This fixes the hardcoded S3 disk name.
Before, if you had a custom S3 disk with a name different than `"s3"`, the `isS3File` function would always return false resulting in errors.

This PR changes the `isS3File` function to check the class type of the adapter instead of the disk name.
This also removes a caching step in order to make sure the adapter is always set correctly.

Closes #10 